### PR TITLE
Fixed getting bug link id from tfs url

### DIFF
--- a/bugtracker-target-tfs/src/main/java/com/fortify/bugtracker/tgt/tfs/connection/TFSRestConnection.java
+++ b/bugtracker-target-tfs/src/main/java/com/fortify/bugtracker/tgt/tfs/connection/TFSRestConnection.java
@@ -119,6 +119,8 @@ public final class TFSRestConnection extends AbstractRestConnection {
 	
 	private String getIssueId(TargetIssueLocator targetIssueLocator) {
 		String id = targetIssueLocator.getId();
+		// Gets the id from the tfs bug link url.
+		// Tfs url is no longer having bugId as query parameter. So the below one doesn't work. It alwasy return null.
 		if ( StringUtils.isBlank(id) ) {
 			String deepLink = targetIssueLocator.getDeepLink();
 			@SuppressWarnings("deprecation")
@@ -129,6 +131,13 @@ public final class TFSRestConnection extends AbstractRestConnection {
 				  return param.getValue();
 			  }
 			}
+		}
+		// Get the bug id from the tfs bug link url (https://domain/bla/blabla/bugId)
+		if(StringUtils.isBlank(id)){
+			String deepLink = targetIssueLocator.getDeepLink();
+			String[] deepLinkSplit = deepLink.split("/", 0);
+			int length = deepLinkSplit.length;
+			return deepLinkSplit[length-1].trim();
 		}
 		return id;
 	}


### PR DESCRIPTION
The existing code assumes that the bug id in tfs url is in the form of https://domain/bla/blabla?id=bugId but this got changed and currently the bug id is in the tfs url is in the format of https://domain/bla/blabla/bugId.

For fixing this, I added some more lines to check if the id is still blank, if yes, then split the deepLinkUrl on '/' and get the last item.